### PR TITLE
Expose volume / muted / defaultMuted properties on HTMLVideoElement

### DIFF
--- a/shaka/src/js/mse/video_element.h
+++ b/shaka/src/js/mse/video_element.h
@@ -74,6 +74,7 @@ class HTMLVideoElement : public dom::Element {
   media::MediaReadyState ready_state;
   bool autoplay;
   bool loop;
+  bool default_muted;
   std::vector<Member<TextTrack>> text_tracks;
   RefPtr<MediaError> error;
 
@@ -91,6 +92,7 @@ class HTMLVideoElement : public dom::Element {
   void SetMuted(bool muted);
   double Volume() const;
   void SetVolume(double volume);
+  ExceptionOr<void> SetVolumeHelper(double volume);
 
   bool Paused() const;
   bool Seeking() const;


### PR DESCRIPTION
- Add defaultMuted member property to HTMLVideoElement object
- Add exceptions for volume values outside the range of 0 - 1
- Add copy constructor to JsError to allow setter functions to throw exceptions