### PR TITLE
Fix HTMLVideoElement playback rate handling

### DIFF
--- a/shaka/src/js/events/event_names.h
+++ b/shaka/src/js/events/event_names.h
@@ -37,6 +37,7 @@ namespace js {
   DEFINE_EVENT(Seeking, "seeking")                       \
   DEFINE_EVENT(Ended, "ended")                           \
   DEFINE_EVENT(CueChange, "cuechange")                   \
+  DEFINE_EVENT(RateChange, "ratechange")                 \
   /* EME events. */                                      \
   DEFINE_EVENT(KeyStatusesChange, "keystatuseschange")   \
   DEFINE_EVENT(Message, "message")                       \

--- a/shaka/src/js/mse/video_element.h
+++ b/shaka/src/js/mse/video_element.h
@@ -87,6 +87,9 @@ class HTMLVideoElement : public dom::Element {
   double Duration() const;
   double PlaybackRate() const;
   void SetPlaybackRate(double rate);
+  ExceptionOr<void> SetPlaybackRateHelper(double rate);
+  double DefaultPlaybackRate() const;
+  ExceptionOr<void> SetDefaultPlaybackRate(double default_playback_rate);
   bool Muted() const;
   void SetMuted(bool muted);
   double Volume() const;
@@ -109,6 +112,8 @@ class HTMLVideoElement : public dom::Element {
   media::PipelineStatus pipeline_status_;
   double volume_;
   bool will_play_;
+  double default_playback_rate_;
+  double playback_rate_;
   bool is_muted_;
   const util::Clock* const clock_;
   std::atomic<bool> shutdown_;


### PR DESCRIPTION
- Add default playback rate member to HTMLVideoElement with a default value of 1
- Store actual playback rate in a local variable so it can be correctly obtained when no media source is attached
- Add and emit ratechange event when appropriate
- Ensure that playback rate is set to default playback rate value when a media source is attached
- Add error and exceptions for invalid rate values