### PR TITLE
Clean up file reading and script execution

### DIFF
--- a/shaka/src/mapping/js_wrappers.h
+++ b/shaka/src/mapping/js_wrappers.h
@@ -308,8 +308,7 @@ bool RunScript(const std::string& path);
  *
  * @param path The file path to the JavaScript file.  This is only used for
  *   logging.
- * @param data The contents of the file.  It must only contain ASCII and must
- *   live for the duration of the current isolate.
+ * @param data The contents of the file.
  * @param data_size The number of bytes in |data|.
  */
 bool RunScript(const std::string& path, const uint8_t* data, size_t data_size);
@@ -321,9 +320,11 @@ bool RunScript(const std::string& path, const uint8_t* data, size_t data_size);
  */
 ReturnVal<JsValue> ParseJsonString(const std::string& json);
 
-
 /** @return A new string object containing the given UTF-8 string. */
 ReturnVal<JsString> JsStringFromUtf8(const std::string& str);
+
+/** @return A new string object containing the given UTF-8 string in bytes. */
+ReturnVal<JsString> JsStringFromUtf8(const uint8_t* data, size_t size);
 
 /** @return The JavaScript value |undefined|. */
 ReturnVal<JsValue> JsUndefined();

--- a/shaka/src/mapping/jsc/js_wrappers.cc
+++ b/shaka/src/mapping/jsc/js_wrappers.cc
@@ -246,9 +246,7 @@ bool RunScript(const std::string& path) {
 }
 
 bool RunScript(const std::string& path, const uint8_t* data, size_t size) {
-  const std::vector<uint16_t> data_utf16(data, data + size);
-  LocalVar<JsString> code =
-      JSStringCreateWithCharacters(data_utf16.data(), data_utf16.size());
+  LocalVar<JsString> code = JsStringFromUtf8(data, size);
   LocalVar<JsString> source = JsStringFromUtf8(path);
 
   JSValueRef except = nullptr;
@@ -265,6 +263,12 @@ ReturnVal<JsValue> ParseJsonString(const std::string& json) {
   return JSValueMakeFromJSONString(GetContext(), input);
 }
 
+ReturnVal<JsString> JsStringFromUtf8(const uint8_t* data, size_t size) {
+  util::CFRef<CFStringRef> cf_str(CFStringCreateWithBytes(
+      nullptr, data, size,
+      kCFStringEncodingUTF8, false));
+  return JSStringCreateWithCFString(cf_str);
+}
 
 ReturnVal<JsString> JsStringFromUtf8(const std::string& str) {
   util::CFRef<CFStringRef> cf_str(CFStringCreateWithBytes(

--- a/shaka/src/mapping/v8/js_wrappers.cc
+++ b/shaka/src/mapping/v8/js_wrappers.cc
@@ -249,7 +249,7 @@ bool RunScript(const std::string& path) {
 }
 
 bool RunScript(const std::string& path, const uint8_t* data, size_t data_size) {
-  v8::Local<v8::String> source = MakeExternalString(data, data_size);
+  v8::Local<v8::String> source = JsStringFromUtf8(data, data_size);
   return RunScriptImpl(path, source);
 }
 
@@ -271,6 +271,12 @@ ReturnVal<JsString> JsStringFromUtf8(const std::string& str) {
   // and may be common, Chromium has a v8AtomicString method for this.
   return v8::String::NewFromUtf8(GetIsolate(), str.c_str(),
                                  v8::NewStringType::kNormal, str.size())
+      .ToLocalChecked();
+}
+
+ReturnVal<JsString> JsStringFromUtf8(const uint8_t* data, size_t size) {
+  return v8::String::NewFromUtf8(GetIsolate(), reinterpret_cast<const char*>(data),
+                                 v8::NewStringType::kNormal, size)
       .ToLocalChecked();
 }
 


### PR DESCRIPTION
- Change file and script data to be stored in a string
- Fix scripts containing any valid unicode characters not being properly converted when loading into JSCore