### PR TITLE
Fix Attr ownerElement not being optional

### DIFF
--- a/shaka/src/js/dom/attr.cc
+++ b/shaka/src/js/dom/attr.cc
@@ -21,15 +21,27 @@ namespace shaka {
 namespace js {
 namespace dom {
 
-Attr::Attr(RefPtr<Element> owner, const std::string& local_name,
+Attr::Attr(RefPtr<Element> owner,
+           const std::string& local_name,
            optional<std::string> namespace_uri,
-           optional<std::string> namespace_prefix, const std::string& value)
-    : Node(ATTRIBUTE_NODE, owner->document()),
-      namespace_uri(namespace_uri),
+           optional<std::string> namespace_prefix,
+           const std::string& value)
+    : Attr(owner->document(), owner, local_name, namespace_uri, namespace_prefix, value) {}
+
+Attr::Attr(RefPtr<Document> document,
+           RefPtr<Element> owner,
+           const std::string& local_name,
+           optional<std::string> namespace_uri,
+           optional<std::string> namespace_prefix,
+           const std::string& value)
+    : Node(ATTRIBUTE_NODE, document),
+      namespace_uri(namespace_uri.has_value() && !namespace_uri.value.empty() ? namespace_uri : nullopt),
       namespace_prefix(namespace_prefix),
       local_name(local_name),
       value(value),
-      owner_element(owner) {}
+      owner_element(owner) {
+  DCHECK(!owner || owner->document() == document);
+}
 
 // \cond Doxygen_Skip
 Attr::~Attr() {}

--- a/shaka/src/js/dom/attr.h
+++ b/shaka/src/js/dom/attr.h
@@ -33,7 +33,15 @@ class Attr final : public Node {
   DECLARE_TYPE_INFO(Attr);
 
  public:
-  Attr(RefPtr<Element> owner, const std::string& local_name,
+  Attr(RefPtr<Element> owner,
+       const std::string& local_name,
+       optional<std::string> namespace_uri,
+       optional<std::string> namespace_prefix,
+       const std::string& value);
+
+  Attr(RefPtr<Document> document,
+       RefPtr<Element> owner,
+       const std::string& local_name,
        optional<std::string> namespace_uri,
        optional<std::string> namespace_prefix,
        const std::string& value);

--- a/shaka/src/js/dom/document.cc
+++ b/shaka/src/js/dom/document.cc
@@ -16,6 +16,7 @@
 
 #include "src/js/dom/comment.h"
 #include "src/js/dom/element.h"
+#include "src/js/dom/attr.h"
 #include "src/js/dom/text.h"
 #include "src/js/mse/video_element.h"
 #include "src/memory/heap_tracer.h"
@@ -64,6 +65,14 @@ RefPtr<Element> Document::DocumentElement() const {
   return nullptr;
 }
 
+RefPtr<Attr> Document::CreateAttribute(const std::string& name) {
+  return new Attr(this, nullptr, util::ToAsciiLower(name), nullopt, nullopt, "");
+}
+
+RefPtr<Attr> Document::CreateAttributeNS(const std::string& namespace_uri, const std::string& name) {
+  return new Attr(this, nullptr, name, namespace_uri, nullopt, "");
+}
+
 RefPtr<Element> Document::CreateElement(const std::string& name) {
   if (name == "video") {
     // This should only be used in Shaka Player integration tests.
@@ -82,6 +91,8 @@ RefPtr<Text> Document::CreateTextNode(const std::string& data) {
 
 
 DocumentFactory::DocumentFactory() {
+  AddMemberFunction("createAttribute", &Document::createAttribute);
+  AddMemberFunction("createAttributeNS", &Document::createAttributeNS);
   AddMemberFunction("createElement", &Document::CreateElement);
   AddMemberFunction("createComment", &Document::CreateComment);
   AddMemberFunction("createTextNode", &Document::CreateTextNode);
@@ -97,8 +108,6 @@ DocumentFactory::DocumentFactory() {
   NotImplemented("createCDATASection");
   NotImplemented("createProcessingInstruction");
 
-  NotImplemented("createAttribute");
-  NotImplemented("createAttributeNS");
   NotImplemented("createRange");
   NotImplemented("createNodeIterator");
   NotImplemented("createTreeWalker");

--- a/shaka/src/js/dom/document.h
+++ b/shaka/src/js/dom/document.h
@@ -24,6 +24,7 @@
 namespace shaka {
 namespace js {
 namespace dom {
+class Attr;
 class Comment;
 class Element;
 class Text;
@@ -59,6 +60,9 @@ class Document : public ContainerNode {
   optional<std::string> TextContent() const override;
 
   RefPtr<Element> DocumentElement() const;
+
+  RefPtr<Attr> CreateAttribute(const std::string& name);
+  RefPtr<Attr> CreateAttributeNS(const std::string& namespace_uri, const std::string& name);
 
   RefPtr<Element> CreateElement(const std::string& name);
   RefPtr<Comment> CreateComment(const std::string& data);


### PR DESCRIPTION
- Add alternate constructor that takes document and owner element values separately
- Add check to ensure that the owner element document is the same as the document if one is provided
- Implement Document createAttribute / createAttributeNS member functions