### PR TITLE
Fix HTMLVideoElement play event not being emitted

### DIFF
--- a/shaka/src/js/mse/video_element.cc
+++ b/shaka/src/js/mse/video_element.cc
@@ -114,19 +114,21 @@ void HTMLVideoElement::OnPipelineStatusChanged(media::PipelineStatus status) {
       ScheduleEvent<events::Event>(EventType::Emptied);
       break;
     case media::PipelineStatus::Playing:
-      if (pipeline_status_ == media::PipelineStatus::Paused) {
+      if (pipeline_status_ == media::PipelineStatus::Paused ||
+          pipeline_status_ == media::PipelineStatus::PlayRequested) {
         ScheduleEvent<events::Event>(EventType::Play);
       } else if (pipeline_status_ == media::PipelineStatus::SeekingPlay) {
         ScheduleEvent<events::Event>(EventType::Seeked);
       } else {
-        DCHECK(pipeline_status_ == media::PipelineStatus::Stalled ||
+        DCHECK(pipeline_status_ == media::PipelineStatus::Buffering ||
                pipeline_status_ == media::PipelineStatus::Initializing);
       }
       ScheduleEvent<events::Event>(EventType::Playing);
       break;
     case media::PipelineStatus::Paused:
       if (pipeline_status_ == media::PipelineStatus::Playing ||
-          pipeline_status_ == media::PipelineStatus::Stalled) {
+          pipeline_status_ == media::PipelineStatus::PlayRequested ||
+          pipeline_status_ == media::PipelineStatus::Buffering) {
         ScheduleEvent<events::Event>(EventType::Pause);
       } else if (pipeline_status_ == media::PipelineStatus::SeekingPause) {
         ScheduleEvent<events::Event>(EventType::Seeked);

--- a/shaka/src/media/pipeline_manager.h
+++ b/shaka/src/media/pipeline_manager.h
@@ -75,8 +75,8 @@ class PipelineManager {
   /** Pauses the video. */
   virtual void Pause();
 
-  /** Called when the video stalls due to lack of content. */
-  virtual void Stalled();
+  /** Called when the video is buffering content. */
+  virtual void Buffering();
 
   /** Called when the video has enough content to play forward. */
   virtual void CanPlay();

--- a/shaka/src/media/pipeline_monitor.cc
+++ b/shaka/src/media/pipeline_monitor.cc
@@ -84,7 +84,7 @@ void PipelineMonitor::ThreadMain() {
       // forward without the correct frames.
       pipeline_->CanPlay();
     } else {
-      pipeline_->Stalled();
+      pipeline_->Buffering();
     }
 
     if (pipeline_->GetPipelineStatus() == PipelineStatus::Initializing) {

--- a/shaka/src/media/types.h
+++ b/shaka/src/media/types.h
@@ -112,6 +112,10 @@ DEFINE_ENUM_AND_TO_STRING(SourceType, DEFINE_ENUM_);
 #define DEFINE_ENUM_(DEFINE)                                              \
   /** The pipeline is starting up. */                                     \
   DEFINE(Initializing)                                                    \
+  /** Playback of the media has been requested, but the pipline has not   \
+   * transitioned to playing yet.                                         \
+   */                                                                     \
+  DEFINE(PlayRequested)                                                   \
   /** The pipeline is playing media. */                                   \
   DEFINE(Playing)                                                         \
   /** The pipeline is paused (by user action). */                         \
@@ -125,11 +129,11 @@ DEFINE_ENUM_AND_TO_STRING(SourceType, DEFINE_ENUM_);
   /** Similar to SeekingPlay, but will remain paused. */                  \
   DEFINE(SeekingPause)                                                    \
   /**                                                                     \
-   * The pipeline is stalled waiting for new content.  This only happens  \
-   * when playing.  If the video is paused, it will be in Paused, even if \
-   * there is no content.                                                 \
+   * The pipeline is buffering while waiting for new content.  This only  \
+   * happens when playing.  If the video is paused, it will be in Paused, \
+   * even if there is no content.                                         \
    */                                                                     \
-  DEFINE(Stalled)                                                         \
+  DEFINE(Buffering)                                                       \
   /** The video has ended and the pipeline is waiting for user action. */ \
   DEFINE(Ended)                                                           \
   /** There was an error that has stopped the pipeline. */                \


### PR DESCRIPTION
- Fixes play event not being emitted after play is called directly or due to autoplay
- Rename Stalled state to Buffering to be more accurate to what it represents
- Add PlayRequested state to distinguish between calling play directly and autoplay