### PR TITLE
Cleanup buffers when they are no longer needed

### DIFF
--- a/shaka/src/js/mse/source_buffer.cc
+++ b/shaka/src/js/mse/source_buffer.cc
@@ -204,6 +204,7 @@ ExceptionOr<void> SourceBuffer::SetAppendWindowEnd(double window_end) {
 void SourceBuffer::OnAppendComplete(media::Status status) {
   VLOG(1) << "Finish appending media segment: " << status;
   updating = false;
+  append_buffer_.Clear();
   if (status != media::Status::Success) {
     Abort();
     ScheduleEvent<events::Event>(EventType::Error);

--- a/shaka/src/mapping/byte_buffer.cc
+++ b/shaka/src/mapping/byte_buffer.cc
@@ -242,6 +242,7 @@ void ByteBuffer::Trace(memory::HeapTracer* tracer) const {
 }
 
 void ByteBuffer::ClearFields() {
+  buffer_.reset();
   ptr_ = nullptr;
   size_ = 0;
   own_ptr_ = false;


### PR DESCRIPTION
- Release ByteBuffer JS value earlier
- Explicitly release SourceBuffer append buffer after processing