### PR TITLE
Include player parameter in every client method

### DIFF
--- a/sample_xcode_project/sample_xcode_project/PlayerViewController.m
+++ b/sample_xcode_project/sample_xcode_project/PlayerViewController.m
@@ -214,11 +214,11 @@ typedef enum { kPlayPauseIconPlay, kPlayPauseIconPause, kPlayPauseIconReplay } P
 
 #pragma mark - ShakaPlayerClient
 
-- (void)onPlayerError:(ShakaPlayerError *)error {
+- (void)onPlayer:(ShakaPlayer *)player error:(ShakaPlayerError *)error {
   [self.errorDisplayView applyError:[error message]];
 }
 
-- (void)onPlayerBufferingChange:(BOOL)is_buffering {
+- (void)onPlayer:(ShakaPlayer *)player bufferingChange:(BOOL)is_buffering {
   if (is_buffering) {
     [self.spinner startAnimating];
   } else {

--- a/shaka/docs/tutorial_setup.md
+++ b/shaka/docs/tutorial_setup.md
@@ -116,7 +116,7 @@ import UIKit
 import ShakaPlayerEmbedded
 
 class ViewController: UIViewController, ShakaPlayerClient {
-  func onPlayerError(_ error: ShakaPlayerError!) {
+  func onPlayer(_ player: ShakaPlayer!, error: ShakaPlayerError!) {
     print("Got Shaka Player Error: \(error.message)")
   }
 
@@ -159,7 +159,7 @@ Go to `ViewController.m`, and replace its contents with the following code:
 
 @implementation ViewController
 
-- (void)onPlayerError:(ShakaPlayerError *)error {
+- (void)onPlayer:(ShakaPlayer *)player error:(ShakaPlayerError *)error {
   NSLog(@"Got Shaka Player Error: %@", [error message]);
 }
 

--- a/shaka/include/shaka/ShakaPlayer.h
+++ b/shaka/include/shaka/ShakaPlayer.h
@@ -25,6 +25,8 @@
 #include "stats_objc.h"
 #include "track_objc.h"
 
+@class ShakaPlayer;
+
 typedef void (^ShakaPlayerAsyncBlock)(ShakaPlayerError *);
 
 typedef NS_ENUM(NSInteger, ShakaPlayerLogLevel) {
@@ -52,55 +54,55 @@ SHAKA_EXPORT
  * Called when an asynchronous error occurs.  This is called on the main thread
  * and is only called when there isn't a block callback to give the error to.
  */
-- (void)onPlayerError:(ShakaPlayerError *)error;
+- (void)onPlayer:(ShakaPlayer *)player error:(ShakaPlayerError *)error;
 
 /**
  * Called when the buffering state of the Player changes.
  */
-- (void)onPlayerBufferingChange:(BOOL)is_buffering;
+- (void)onPlayer:(ShakaPlayer *)player bufferingChange:(BOOL)is_buffering;
 
 
 /**
  * Called when the video starts playing after startup or a call to Pause().
  */
-- (void)onPlayerPlayingEvent;
+- (void)onPlayerPlayingEvent:(ShakaPlayer *)player;
 
 /**
  * Called when the video gets paused due to a call to Pause().
  */
-- (void)onPlayerPauseEvent;
+- (void)onPlayerPauseEvent:(ShakaPlayer *)player;
 
 /**
  * Called when the video plays to the end of the content.
  */
-- (void)onPlayerEndedEvent;
+- (void)onPlayerEndedEvent:(ShakaPlayer *)player;
 
 
 /**
  * Called when the video starts seeking.  This may be called multiple times
  * in a row due to Shaka Player repositioning the playhead.
  */
-- (void)onPlayerSeekingEvent;
+- (void)onPlayerSeekingEvent:(ShakaPlayer *)player;
 
 /**
  * Called when the video completes seeking.  This happens once content is
  * available and the playhead can move forward.
  */
-- (void)onPlayerSeekedEvent;
+- (void)onPlayerSeekedEvent:(ShakaPlayer *)player;
 
 /** Called once MSE-based playback has started. */
-- (void)onPlayerAttachMse;
+- (void)onPlayerAttachMse:(ShakaPlayer *)player;
 
 /**
  * Called once src= based playback has started.  Once this is called, the avPlayer property
  * will be valid and point to the AVPlayer instance being used.
  */
-- (void)onPlayerAttachSource;
+- (void)onPlayerAttachSource:(ShakaPlayer *)player;
 
 /**
  * Called once playback is detached.  If this was src= playback, the AVPlayer is no longer usable.
  */
-- (void)onPlayerDetach;
+- (void)onPlayerDetach:(ShakaPlayer *)player;
 
 @end
 

--- a/shaka/src/public/ShakaPlayer.mm
+++ b/shaka/src/public/ShakaPlayer.mm
@@ -143,6 +143,7 @@ std::shared_ptr<shaka::JsManager> ShakaGetGlobalEngine() {
 
 - (instancetype)initWithClient:(id<ShakaPlayerClient>)client {
   if ((self = [super init])) {
+    _client.SetPlayer(self);
     if (![self setClient:client])
       return nil;
   }
@@ -150,7 +151,6 @@ std::shared_ptr<shaka::JsManager> ShakaGetGlobalEngine() {
 }
 
 - (BOOL)setClient:(id<ShakaPlayerClient>)client {
-  _client.SetPlayer(self);
   _client.SetClient(client);
   if (_engine) {
     return YES;

--- a/shaka/src/public/ShakaPlayer.mm
+++ b/shaka/src/public/ShakaPlayer.mm
@@ -34,7 +34,6 @@
 #include "src/public/error_objc+Internal.h"
 #include "src/util/macros.h"
 #include "src/util/objc_utils.h"
-#import "ShakaPlayer.h"
 
 
 namespace {


### PR DESCRIPTION
Solves #94 

Please note that I think the proper way to do this would be to create a constructor in the `NativeClient` class with the `ShakaPlayer` which has created it. I don't know enough C++ to do this, as it seems that, after including an instance variable with a pointer to the `ShakaPlayer`, the copy assignment operator is implicitly deleted and you can't later create the object and assign it to the `_client` instance variable in the `ShakaPlayer` Objective C class.