### PR TITLE
Fixing almost infinity loop in FillSilence for wrong bytes length

### DIFF
--- a/shaka/src/media/audio_renderer_common.cc
+++ b/shaka/src/media/audio_renderer_common.cc
@@ -290,6 +290,16 @@ void AudioRendererCommon::ThreadMain() {
         clock_->SleepSeconds(delay);
         if (shutdown_)
           return;
+        // Mute audio when player is not playing after sleep
+        const bool is_playing =
+                player_->PlaybackRate() == 1 &&
+                player_->PlaybackState() == VideoPlaybackState::Playing;
+        SetDeviceState(is_playing);
+        if (!is_playing) {
+            std::unique_lock<Mutex> lock(mutex_);
+            on_play_.ResetAndWaitWhileUnlocked(lock);
+            continue;
+        }
         time = player_->CurrentTime();
       }
 


### PR DESCRIPTION
In reaction on my issue #175, I found fix:

During debugging reason of app crashing during another load of manifest when audio from previous manifest hasn't start playing, I found out that `time = player_->CurrentTime()` is returning 0.
Later function GetSyncBytes returns wrong big number, because `(buffer_end - next->pts)` in `GetSyncBytes` is deducting:
`0 - SECONDS.`
This cause that function FillSilence in audio_renderer_common start to loop on huge bytes size and ends almost in infinity loop. Results is app crash like it was described in issue #175.

I think that after `clock_->SleepSeconds(delay)` there should be check on player status in same way as on each thread loop start. Additionally, there has to be `std::unique_lock<Mutex> lock(mutex_)` to lock mutex which was unlocked before sleep.
If there is no check, `time = player_->CurrentTime()` returns 0 after sleep in specific situation.


Fixes #175