### PR TITLE
Fixing paused video doesn't react on changing device orientation

### DIFF
--- a/shaka/src/media/apple_video_renderer.cc
+++ b/shaka/src/media/apple_video_renderer.cc
@@ -59,7 +59,8 @@ CGImageRef AppleVideoRenderer::Impl::Render(
   if (delay)
     *delay = loc_delay;
 
-  if (!frame || frame == prev_frame_)
+  const bool is_paused = player_->PlaybackState() == VideoPlaybackState::Paused;
+  if (!frame || (frame == prev_frame_ && !is_paused))
     return nullptr;
 
   if (sample_aspect_ratio)

--- a/shaka/src/media/video_renderer_common.h
+++ b/shaka/src/media/video_renderer_common.h
@@ -51,12 +51,13 @@ class VideoRendererCommon : public VideoRenderer, MediaPlayer::Client {
   struct VideoPlaybackQuality VideoPlaybackQuality() const override;
   bool SetVideoFillMode(VideoFillMode mode) override;
 
+ protected:
+  mutable Mutex mutex_;
+  const MediaPlayer* player_;
+
  private:
   void OnSeeking() override;
 
-  mutable Mutex mutex_;
-
-  const MediaPlayer* player_;
   const DecodedStream* input_;
   struct VideoPlaybackQuality quality_;
   std::atomic<VideoFillMode> fill_mode_;


### PR DESCRIPTION
Reacting on #194 I found that problem is in condiiton:
`
frame == prev_frame_
`
in `apple_video_renderer.cc`. It returns `nullptr` in this case and `renderLoop` inside `ShakaPlayerView.mm` doesn't pass:
 `if (CGImageRef image = _player.videoRenderer->Render(nullptr, &aspect_ratio)) {.. `
condition

So solution would be remove `frame == prev_frame_`, but this could brings unnecessary overhead to rendering loop.
So I limit this condition only for case,  that video is paused. To make it possible, I have to make `player_` property protected, to be inheritable from parent class. Also I had to move `mutex_` up to player_, due to some compilations errors.
This works and bug is fixed.

I could imagine there should be better solution, directly in file `ShakaPlayerView.mm` - watching screen orientation change and only forcing recalculation in that case. Additionaly storing some informations from last render and use them for paused state. But I don't want to make hude updates in original source code.

Fixes #194